### PR TITLE
Add --selector to "helm-dump init" command

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,13 +137,13 @@ spec:
   template:
     metadata:
       labels:
-	app: nginx
+        app: nginx
     spec:
       containers:
-	- name: nginx
-	  image: nginx:1.14.2
-	  ports:
-	    - containerPort: 80
+        - name: nginx
+          image: nginx:1.14.2
+          ports:
+            - containerPort: 80
 ```
 
 Now that we have inspected the contents of `nginx-deployment.yaml`, we can install it in the cluster using `kubectl`:
@@ -203,7 +203,7 @@ metadata:
     app: nginx
     app.kubernetes.io/instance: '{{ $.Release.Name }}'
     app.kubernetes.io/name: '{{ template "my-chart.fullname" $ }}'
-    helm-dump: "true"
+    helm-dump: "please"
   name: nginx-deployment-{{ .Release.Name }}
   namespace: default
 spec:
@@ -222,18 +222,18 @@ spec:
     metadata:
       creationTimestamp: null
       labels:
-	app: nginx
+        app: nginx
     spec:
       containers:
       - image: nginx:1.14.2
-	imagePullPolicy: IfNotPresent
-	name: nginx
-	ports:
-	- containerPort: 80
-	  protocol: TCP
-	resources: {}
-	terminationMessagePath: /dev/termination-log
-	terminationMessagePolicy: File
+        imagePullPolicy: IfNotPresent
+        name: nginx
+        ports:
+        - containerPort: 80
+          protocol: TCP
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler
@@ -334,8 +334,8 @@ helm list
 ```
 
 ```text
-NAME  	NAMESPACE	REVISION	UPDATED                                 	STATUS  	CHART         	APP VERSION
-my-app	default  	1       	2022-04-11 12:33:33.854705256 +0200 CEST	deployed	my-chart-0.1.0	           
+NAME    NAMESPACE   REVISION    UPDATED                                     STATUS      CHART           APP VERSION
+my-app  default     1           2022-04-11 12:33:33.854705256 +0200 CEST    deployed    my-chart-0.1.0
 ```
 
 Let's end this section by checking the resources we've created so far:

--- a/README.md
+++ b/README.md
@@ -105,6 +105,268 @@ $ helm plugin list
 NAME    VERSION DESCRIPTION                                                           
 dump    0.2.1   A Helm plugin that creates a chart from a cluster's existing resources
 ```
+
+# Quickstart
+
+This quickstart showcases the `helm-dump` Helm plugin, which one you to create a Helm chart using as
+starting point existing resources from an available Kubernetes cluster.
+
+It contains four parts:
+
+1.  Installing the example deployment
+2.  Extracting a Helm Chart
+3.  Installing the Helm Chart
+
+# Installing the template deployment
+
+Let's start installing a simple deployment resource in the cluster, for example the following resource:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  namespace: default
+  labels:
+    app: nginx
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+	app: nginx
+    spec:
+      containers:
+	- name: nginx
+	  image: nginx:1.14.2
+	  ports:
+	    - containerPort: 80
+```
+
+Now that we have inspected the contents of `nginx-deployment.yaml`, we can install it in the cluster using `kubectl`:
+
+```shell
+kubectl apply -f nginx-deployment.yaml
+```
+
+```text
+deployment.apps/nginx-deployment created
+```
+
+Now that we're happy with the deployment, it is fine to label the `Deployment` resource to be picked up by `helm dump init` on the next step:
+
+```shell
+kubectl label deployment nginx-deployment helm-dump=true
+```
+
+```text
+deployment.apps/nginx-deployment labeled
+```
+
+
+# Extracting a Helm Chart
+
+Now that we have a template deployment running, `helm dump init` can be used to extract it to a Helm chart:
+
+```shell
+helm dump init -l helm-dump=true my-chart /tmp/helm-dump-init-demo
+```
+
+Please note the usage of `-l helm-dump=true`: the `-l` option is equivalent to `kubectl`'s, so refer to `kubectl --help` for more information regarding its usage and semantics.
+
+The <file:///tmp/helm-dump-init-demo/my-chart-0.1.0.tgz> file should be available, so let's inspect its contents.
+
+
+## `Chart.yaml`
+
+```yaml
+apiVersion: v2
+name: my-chart
+version: 0.1.0
+```
+
+
+## `templates/nginx-deployment_apps_v1.yaml`
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    deployment.kubernetes.io/revision: "1"
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"apps/v1","kind":"Deployment","metadata":{"annotations":{},"labels":{"app":"nginx"},"name":"nginx-deployment","namespace":"default"},"spec":{"replicas":3,"selector":{"matchLabels":{"app":"nginx"}},"template":{"metadata":{"labels":{"app":"nginx"}},"spec":{"containers":[{"image":"nginx:1.14.2","name":"nginx","ports":[{"containerPort":80}]}]}}}}
+  labels:
+    app: nginx
+    app.kubernetes.io/instance: '{{ $.Release.Name }}'
+    app.kubernetes.io/name: '{{ template "my-chart.fullname" $ }}'
+    helm-dump: "true"
+  name: nginx-deployment-{{ .Release.Name }}
+  namespace: default
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 3
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: nginx
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+	app: nginx
+    spec:
+      containers:
+      - image: nginx:1.14.2
+	imagePullPolicy: IfNotPresent
+	name: nginx
+	ports:
+	- containerPort: 80
+	  protocol: TCP
+	resources: {}
+	terminationMessagePath: /dev/termination-log
+	terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+```
+
+
+## `templates/_helpers.tpl`
+
+```text
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "my-chart.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "my-chart.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "my-chart.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "my-chart.labels" -}}
+helm.sh/chart: {{ include "my-chart.chart" . }}
+{{ include "my-chart.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "my-chart.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "my-chart.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "my-chart.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "my-chart.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+```
+
+
+# Installing the Chart
+
+Once the Helm Chart has been created, it can be used to install a new release:
+
+```shell
+helm install my-app my-chart-0.1.0.tgz
+```
+
+```text
+NAME: my-app
+LAST DEPLOYED: Mon Apr 11 12:33:33 2022
+NAMESPACE: default
+STATUS: deployed
+REVISION: 1
+TEST SUITE: None
+```
+
+Everything going well, we should now see the release installed in the cluster:
+
+```shell
+helm list
+```
+
+```text
+NAME  	NAMESPACE	REVISION	UPDATED                                 	STATUS  	CHART         	APP VERSION
+my-app	default  	1       	2022-04-11 12:33:33.854705256 +0200 CEST	deployed	my-chart-0.1.0	           
+```
+
+Let's end this section by checking the resources we've created so far:
+
+```shell
+kubectl get all
+```
+
+```text
+NAME                                          READY   STATUS    RESTARTS   AGE
+pod/nginx-deployment-9456bbbf9-4jgfc          1/1     Running   0          2m29s
+pod/nginx-deployment-9456bbbf9-mfpdc          1/1     Running   0          2m29s
+pod/nginx-deployment-9456bbbf9-w5h4f          1/1     Running   0          2m29s
+pod/nginx-deployment-my-app-9456bbbf9-4gkzx   1/1     Running   0          24s
+pod/nginx-deployment-my-app-9456bbbf9-h2c2n   1/1     Running   0          24s
+pod/nginx-deployment-my-app-9456bbbf9-rnmq2   1/1     Running   0          24s
+
+NAME                 TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)   AGE
+service/kubernetes   ClusterIP   10.96.0.1    <none>        443/TCP   6d1h
+
+NAME                                      READY   UP-TO-DATE   AVAILABLE   AGE
+deployment.apps/nginx-deployment          3/3     3            3           2m29s
+deployment.apps/nginx-deployment-my-app   3/3     3            3           24s
+
+NAME                                                DESIRED   CURRENT   READY   AGE
+replicaset.apps/nginx-deployment-9456bbbf9          3         3         3       2m29s
+replicaset.apps/nginx-deployment-my-app-9456bbbf9   3         3         3       24s
+```
+
+As expected, there's one deployment `nginx-deployment` that was extracted by the `helm dump init` operation, and the deployment managed by Helm, `nginx-deployment-my-app`.
+
 ## License
 
 Apache License Version 2.0

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ deployment.apps/nginx-deployment created
 Now that we're happy with the deployment, it is fine to label the `Deployment` resource to be picked up by `helm dump init` on the next step:
 
 ```shell
-kubectl label deployment nginx-deployment helm-dump=true
+kubectl label deployment nginx-deployment helm-dump=please
 ```
 
 ```text
@@ -172,10 +172,10 @@ deployment.apps/nginx-deployment labeled
 Now that we have a template deployment running, `helm dump init` can be used to extract it to a Helm chart:
 
 ```shell
-helm dump init -l helm-dump=true my-chart /tmp/helm-dump-init-demo
+helm dump init -l helm-dump=please my-chart /tmp/helm-dump-init-demo
 ```
 
-Please note the usage of `-l helm-dump=true`: the `-l` option is equivalent to `kubectl`'s, so refer to `kubectl --help` for more information regarding its usage and semantics.
+Please note the usage of `-l helm-dump=please`: the `-l` option is equivalent to `kubectl`'s, so refer to `kubectl --help` for more information regarding its usage and semantics.
 
 The <file:///tmp/helm-dump-init-demo/my-chart-0.1.0.tgz> file should be available, so let's inspect its contents.
 

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -36,6 +36,7 @@ type InitCommand struct {
 	*cobra.Command
 	PluginDir       string
 	SkipPlugins     []string
+	LabelSelector   string
 	Logger          *logrus.Logger
 	DynamicClient   dynamic.Interface
 	ConfigFlags     *genericclioptions.ConfigFlags
@@ -74,6 +75,7 @@ func NewInitCmd(
 
 	initCmd.PersistentFlags().StringVarP(&initCmd.PluginDir, "plugin-dir", "P", pluginDir, "The path where binary plugins are located")
 	initCmd.PersistentFlags().StringSliceVarP(&initCmd.SkipPlugins, "skip-plugins", "S", nil, "A comma-separated list of plugins to skip")
+	initCmd.PersistentFlags().StringVarP(&initCmd.LabelSelector, "selector", "l", "", "A comma separated list of labels to filter resources")
 
 	return initCmd, nil
 }
@@ -142,6 +144,7 @@ func (c *InitCommand) runE(cmd *cobra.Command, args []string) error {
 			c.Logger.Debugf("Namespace: %q", *c.ConfigFlags.Namespace)
 
 			p := pager.New(func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
+				opts.LabelSelector = c.LabelSelector
 				return resourceInterface.Namespace(*c.ConfigFlags.Namespace).List(ctx, opts)
 			})
 

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -149,7 +149,7 @@ func (c *InitCommand) runE(cmd *cobra.Command, args []string) error {
 				return resourceInterface.List(ctx, opts)
 			})
 
-			list, _, err := p.List(cmd.Context(), metav1.ListOptions{})
+			list, _, err := p.List(cmd.Context(), metav1.ListOptions{LabelSelector: c.LabelSelector})
 			if err != nil {
 				c.Logger.Errorf("%s", err)
 				continue

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -2,26 +2,68 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/require"
-	"helm.sh/helm/v3/pkg/chart/loader"
-	"helm.sh/helm/v3/pkg/chartutil"
 	"io/ioutil"
-	appsv1 "k8s.io/api/apps/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
-	kdiscovery "k8s.io/client-go/discovery"
-	fakediscovery "k8s.io/client-go/discovery/fake"
-	fakedynamic "k8s.io/client-go/dynamic/fake"
 	"os"
 	"path"
 	"testing"
 
+	"github.com/ghodss/yaml"
+	"github.com/pmezard/go-difflib/difflib"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"helm.sh/helm/v3/pkg/chart/loader"
+	"helm.sh/helm/v3/pkg/chartutil"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	kdiscovery "k8s.io/client-go/discovery"
+	fakediscovery "k8s.io/client-go/discovery/fake"
+	fakedynamic "k8s.io/client-go/dynamic/fake"
+	ktesting "k8s.io/client-go/testing"
+
 	"github.com/redhat-developer/helm-dump/pkg/test"
 )
 
+var (
+	ContextLines = 4
+)
+
+func newFakeCachedDiscovery(dynamicClient *fakedynamic.FakeDynamicClient) *FakeCachedDiscovery {
+	discoveryClient := &FakeCachedDiscovery{
+		FakeDiscovery: &fakediscovery.FakeDiscovery{
+			Fake: &dynamicClient.Fake,
+		},
+	}
+
+	discoveryClient.Resources = []*metav1.APIResourceList{
+		{
+			GroupVersion: appsv1.SchemeGroupVersion.String(),
+			APIResources: []metav1.APIResource{
+				{
+					Name:       "deployments",
+					Namespaced: true,
+					Kind:       "Deployment",
+					Group:      "apps",
+					Version:    "v1",
+					Verbs: []string{
+						"list",
+						"create",
+						"get",
+						"delete",
+					},
+				},
+			},
+		},
+	}
+
+	return discoveryClient
+}
+
 func TestNewInitCmd(t *testing.T) {
+
 	logger := logrus.New()
 	logger.Level = logrus.DebugLevel
 
@@ -47,21 +89,9 @@ func TestNewInitCmd(t *testing.T) {
 		scheme := runtime.NewScheme()
 
 		dynamicClient := fakedynamic.NewSimpleDynamicClient(scheme, deployment)
-		discoveryClient := &FakeCachedDiscovery{
-			FakeDiscovery: &fakediscovery.FakeDiscovery{
-				Fake: &dynamicClient.Fake,
-			},
-		}
-		discoveryClient.Resources = []*metav1.APIResourceList{
-			{
-				GroupVersion: appsv1.SchemeGroupVersion.String(),
-				APIResources: []metav1.APIResource{
-					{Name: "deployments", Namespaced: true, Kind: "Deployment", Group: "apps", Version: "v1", Verbs: []string{"list", "create", "get", "delete"}},
-				},
-			},
-		}
-		configFlags := genericclioptions.NewConfigFlags(true)
+		discoveryClient := newFakeCachedDiscovery(dynamicClient)
 
+		configFlags := genericclioptions.NewConfigFlags(true)
 		cmd, _ := NewInitCmd(configFlags, logger)
 		cmd.PluginDir = "../plugins/helm_dump_init/dist/"
 		cmd.DiscoveryClient = discoveryClient
@@ -74,6 +104,18 @@ func TestNewInitCmd(t *testing.T) {
 		require.NoError(t, cmd.Execute(), "Cmd must not return an error")
 
 		// Assert
+		expectedActions := []ktesting.Action{
+			ktesting.NewListAction(
+				schema.GroupVersionResource{Resource: "deployments", Group: "apps", Version: "v1"},
+				schema.GroupVersionKind{Kind: "Deployment", Group: "apps", Version: "v1"},
+				"default",
+				metav1.ListOptions{},
+			),
+		}
+
+		actualActions := FilterActions(discoveryClient.Actions())
+		CheckActions(t, expectedActions, actualActions)
+
 		expectedChartPath := path.Join(outDir, fmt.Sprintf("%s-%s.tgz", chartName, chartVersion))
 		_, err = os.Stat(expectedChartPath)
 		require.NoError(t, err, "%q should exist", expectedChartPath)
@@ -89,7 +131,67 @@ func TestNewInitCmd(t *testing.T) {
 
 		maybeHelpers := chrt.Templates[1]
 		require.Equal(t, chartutil.HelpersName, maybeHelpers.Name)
+	})
 
+	t.Run("using-selector", func(t *testing.T) {
+		// Arrange
+		chartName := "my-chart"
+		chartVersion := "0.1.0"
+		labelSelector := "helm-dump=please"
+
+		outDir, err := ioutil.TempDir(os.TempDir(), "helm-dump")
+		require.NoError(t, err, "temp directory is required for testing")
+
+		deployment1 := test.LoadYamlFixture(t, "init_test/using-selector/nginx-deployment1.yaml")
+		deployment2 := test.LoadYamlFixture(t, "init_test/using-selector/nginx-deployment2.yaml")
+		scheme := runtime.NewScheme()
+
+		dynamicClient := fakedynamic.NewSimpleDynamicClient(scheme, deployment1, deployment2)
+		discoveryClient := newFakeCachedDiscovery(dynamicClient)
+
+		configFlags := genericclioptions.NewConfigFlags(true)
+		cmd, _ := NewInitCmd(configFlags, logger)
+
+		cmd.PluginDir = "../plugins/helm_dump_init/dist/"
+		cmd.DiscoveryClient = discoveryClient
+		cmd.DynamicClient = dynamicClient
+
+		cmd.SetArgs([]string{
+			"--namespace", "default",
+			"-l", labelSelector,
+			chartName, outDir})
+
+		// Act
+		require.NoError(t, cmd.Execute(), "Cmd must not return an error")
+
+		// Assert
+		expectedActions := []ktesting.Action{
+			ktesting.NewListAction(
+				schema.GroupVersionResource{Resource: "deployments", Group: "apps", Version: "v1"},
+				schema.GroupVersionKind{Kind: "Deployment", Group: "apps", Version: "v1"},
+				"default",
+				metav1.ListOptions{LabelSelector: labelSelector},
+			),
+		}
+
+		actualActions := FilterActions(discoveryClient.Actions())
+		CheckActions(t, expectedActions, actualActions)
+
+		expectedChartPath := path.Join(outDir, fmt.Sprintf("%s-%s.tgz", chartName, chartVersion))
+		_, err = os.Stat(expectedChartPath)
+		require.NoError(t, err, "%q should exist", expectedChartPath)
+
+		chrt, err := loader.LoadFile(expectedChartPath)
+		require.NoError(t, err, "%q should be a chart", expectedChartPath)
+
+		require.Len(t, chrt.Templates, 2, "chart should contain %d templates, found %d", 2, len(chrt.Templates))
+
+		maybeDeployment := chrt.Templates[0]
+		actual := test.LoadBytesFixture(t, maybeDeployment.Data)
+		require.Equal(t, "nginx-deployment1-{{ .Release.Name }}", actual.GetName(), "name should match; did you build helm_dump_init crane plugin?")
+
+		maybeHelpers := chrt.Templates[1]
+		require.Equal(t, chartutil.HelpersName, maybeHelpers.Name)
 	})
 }
 
@@ -105,4 +207,63 @@ func (f *FakeCachedDiscovery) Invalidate() {
 	// no-op
 }
 
+func CheckActions(t *testing.T, expected, actual []ktesting.Action) {
+	for i, action := range actual {
+		CheckAction(t, expected[i], action)
+	}
+}
+
+func CheckAction(t *testing.T, expected, actual ktesting.Action) {
+	if !equality.Semantic.DeepEqual(expected, actual) {
+		diff, err := YamlDiff(expected, actual)
+		if err != nil {
+			panic(fmt.Sprintf("couldn't generate yaml diff: %s", err))
+		}
+		t.Errorf("expected action is different from actual:\n%s", diff)
+	}
+}
+
+func FilterActions(actions []ktesting.Action) []ktesting.Action {
+	filtered := make([]ktesting.Action, 0)
+	for _, v := range actions {
+		if ShouldSkip(v) {
+			continue
+		}
+		filtered = append(filtered, v)
+	}
+	return filtered
+}
+
+func ShouldSkip(action ktesting.Action) bool {
+	if action.GetResource().Resource == "group" ||
+		action.GetResource().Resource == "resource" ||
+		action.GetResource().Resource == "version" {
+		return true
+	}
+	return false
+}
+
+func YamlDiff(expected interface{}, actual interface{}) (string, error) {
+	yamlActual, err := yaml.Marshal(actual)
+	if err != nil {
+		return "", err
+	}
+
+	yamlExpected, err := yaml.Marshal(expected)
+	if err != nil {
+		return "", err
+	}
+
+	diff := difflib.UnifiedDiff{
+		A:        difflib.SplitLines(string(yamlExpected)),
+		B:        difflib.SplitLines(string(yamlActual)),
+		FromFile: "Expected",
+		ToFile:   "Actual",
+		Context:  ContextLines,
+	}
+
+	return difflib.GetUnifiedDiffString(diff)
+}
+
+var _ kdiscovery.DiscoveryInterface = &FakeCachedDiscovery{}
 var _ kdiscovery.CachedDiscoveryInterface = &FakeCachedDiscovery{}

--- a/cmd/init_test/using-selector/nginx-deployment1.yaml
+++ b/cmd/init_test/using-selector/nginx-deployment1.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment1
+  namespace: default
+  labels:
+    app: nginx
+    helm-dump: please
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.14.2
+          ports:
+            - containerPort: 80

--- a/cmd/init_test/using-selector/nginx-deployment2.yaml
+++ b/cmd/init_test/using-selector/nginx-deployment2.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment2
+  namespace: default
+  labels:
+    app: nginx
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.14.2
+          ports:
+            - containerPort: 80

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/jarcoal/httpmock v1.1.0
 	github.com/konveyor/crane-lib v0.0.6
+	github.com/pmezard/go-difflib v1.0.0
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.3.0
 	github.com/spf13/viper v1.10.0
@@ -18,6 +19,8 @@ require (
 	k8s.io/apimachinery v0.23.1
 	k8s.io/cli-runtime v0.23.1
 	k8s.io/client-go v0.23.1
+	k8s.io/utils v0.0.0-20210930125809-cb0fa318a74b
+	sigs.k8s.io/controller-runtime v0.10.2
 	sigs.k8s.io/yaml v1.3.0
 )
 
@@ -60,7 +63,6 @@ require (
 	github.com/pelletier/go-toml v1.9.4 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/afero v1.6.0 // indirect
 	github.com/spf13/cast v1.4.1 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
@@ -86,7 +88,6 @@ require (
 	k8s.io/apiextensions-apiserver v0.23.1 // indirect
 	k8s.io/klog/v2 v2.30.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20211115234752-e816edb12b65 // indirect
-	k8s.io/utils v0.0.0-20210930125809-cb0fa318a74b // indirect
 	sigs.k8s.io/json v0.0.0-20211020170558-c049b76a60c6 // indirect
 	sigs.k8s.io/kustomize/api v0.10.1 // indirect
 	sigs.k8s.io/kustomize/kyaml v0.13.0 // indirect

--- a/pkg/test/chartfile.go
+++ b/pkg/test/chartfile.go
@@ -1,0 +1,30 @@
+package test
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"helm.sh/helm/v3/pkg/chart"
+	"helm.sh/helm/v3/pkg/chart/loader"
+)
+
+// RequireChartFileExists ...
+func RequireChartFileExists(
+	t *testing.T,
+	baseDir, chartName, chartVersion string,
+) {
+	expectedChartPath := path.Join(baseDir, fmt.Sprintf("%s-%s.tgz", chartName, chartVersion))
+	_, err := os.Stat(expectedChartPath)
+	require.NoError(t, err, "%q should exist", expectedChartPath)
+}
+
+// RequireChart ...
+func RequireChart(t *testing.T, baseDir, chartName, chartVersion string) *chart.Chart {
+	expectedChartPath := path.Join(baseDir, fmt.Sprintf("%s-%s.tgz", chartName, chartVersion))
+	chrt, err := loader.LoadFile(expectedChartPath)
+	require.NoError(t, err, "%q should be a chart", expectedChartPath)
+	return chrt
+}

--- a/pkg/test/tempdir.go
+++ b/pkg/test/tempdir.go
@@ -1,0 +1,15 @@
+package test
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TempDir(t *testing.T) string {
+	outDir, err := ioutil.TempDir(os.TempDir(), "helm-dump")
+	require.NoError(t, err)
+	return outDir
+}

--- a/plugins/helm_dump_init/helm_dump_init.go
+++ b/plugins/helm_dump_init/helm_dump_init.go
@@ -22,44 +22,40 @@ var helmNameFmt = "%s-{{ .Release.Name }}"
 func Run(request transform.PluginRequest) (transform.PluginResponse, error) {
 	obj := request.Unstructured
 	resp := transform.PluginResponse{
-		Version:    "v1",
-		IsWhiteOut: true,
-		Patches:    nil,
+		Version: "v1",
+		Patches: nil,
 	}
 
 	chartName, ok := request.Extras["chart-name"]
 	if !ok {
 		return transform.PluginResponse{}, fmt.Errorf("chart-name should be informed")
 	}
-	if obj.GetKind() == "Deployment" {
-		var opsJSON []string
 
-		// patch the object's name accordingly
-		newName := fmt.Sprintf(helmNameFmt, obj.GetName())
-		opsJSON = append(opsJSON, fmt.Sprintf(`{"op": "add", "path": "/metadata/name", "value": %q}`, newName))
+	var opsJSON []string
 
-		if labels := obj.GetLabels(); labels == nil {
-			opsJSON = append(opsJSON, `{"op": "add", "path": "/metadata/labels", "value": {}}`)
-		}
+	// patch the object's name accordingly
+	newName := fmt.Sprintf(helmNameFmt, obj.GetName())
+	opsJSON = append(opsJSON, fmt.Sprintf(`{"op": "add", "path": "/metadata/name", "value": %q}`, newName))
 
-		opsJSON = append(opsJSON,
-			fmt.Sprintf(`{"op": "add", "path": "/metadata/labels/app.kubernetes.io~1name", "value": "{{ template \"%s.fullname\" $ }}"}`, chartName),
-			`{"op": "add", "path": "/metadata/labels/app.kubernetes.io~1instance", "value": "{{ $.Release.Name }}"}`,
-		)
-
-		opsJSON = append(opsJSON,
-			`{"op": "remove", "path": "/metadata/managedFields"}`)
-
-		patchJSON := fmt.Sprintf("[%s]", strings.Join(opsJSON, ","))
-
-		patch, err := jsonpatch.DecodePatch([]byte(patchJSON))
-		if err != nil {
-			return transform.PluginResponse{}, err
-		}
-
-		resp.Patches = patch
-		resp.IsWhiteOut = false
+	if labels := obj.GetLabels(); labels == nil {
+		opsJSON = append(opsJSON, `{"op": "add", "path": "/metadata/labels", "value": {}}`)
 	}
+
+	opsJSON = append(opsJSON,
+		fmt.Sprintf(`{"op": "add", "path": "/metadata/labels/app.kubernetes.io~1name", "value": "{{ template \"%s.fullname\" $ }}"}`, chartName),
+		`{"op": "add", "path": "/metadata/labels/app.kubernetes.io~1instance", "value": "{{ $.Release.Name }}"}`,
+	)
+
+	opsJSON = append(opsJSON, `{"op": "remove", "path": "/metadata/managedFields"}`)
+
+	patchJSON := fmt.Sprintf("[%s]", strings.Join(opsJSON, ","))
+
+	patch, err := jsonpatch.DecodePatch([]byte(patchJSON))
+	if err != nil {
+		return transform.PluginResponse{}, err
+	}
+
+	resp.Patches = patch
 
 	return resp, nil
 }


### PR DESCRIPTION
This change adds the `--selector` option to "helm-dump init" command so users can filter cluster resources to be added in the chart using their labels.